### PR TITLE
feat(app): hot-swap seats

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,8 +24,9 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/src/renderer/src/BananasTypes.ts
+++ b/src/renderer/src/BananasTypes.ts
@@ -1,3 +1,15 @@
+export enum BananasConnectionState {
+  CONNECTED = 'connected',
+  DISCONNECTED = 'disconnected',
+  FAILED = 'failed',
+  CLOSED = 'closed'
+}
+
+export enum BananasReadyState {
+  READY = 'ready',
+  UNINITIALIZED = 'uninitialized'
+}
+
 type BananasRemoteCursorMovement = {
   x: number
   y: number

--- a/src/renderer/src/BananasTypes.ts
+++ b/src/renderer/src/BananasTypes.ts
@@ -1,9 +1,13 @@
+type BananasRemoteCursorMovement = {
+  x: number
+  y: number
+}
+
 export type BananasRemoteCursorData = {
   id: string
   name: string
   color: string
-  x: number
-  y: number
+  movements: BananasRemoteCursorMovement[]
 }
 
 type IceServer = {

--- a/src/renderer/src/RemoteScreen.svelte
+++ b/src/renderer/src/RemoteScreen.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte'
+  import { makeVideoDraggable, getUUIDv4 } from './Utils'
+  import WebRTC from './WebRTC.svelte'
+
+  export let remoteScreen: HTMLVideoElement
+  export let webRTCComponent: WebRTC | null = null
+  export let isReady: boolean = false
+  export let isStreaming = false
+  export let receivingRemoteScreen: boolean = false
+
+  // Time interval for batching cursor updates (in ms)
+  const BATCH_SEND_INTERVAL = 100
+
+  let cursorMovementQueue: { x: number; y: number }[] = []
+  let batchTimer: number | null = null
+
+  let isRemoteScreenVisible = false
+
+  let UUID = getUUIDv4()
+  let zoomFactor = 1
+  let settings = null
+
+  $: isRemoteScreenVisible = isReady && !isStreaming && receivingRemoteScreen
+
+  function sendBatchedCursorUpdates(): void {
+    if (cursorMovementQueue.length > 0) {
+      webRTCComponent.UpdateRemoteCursor({
+        movements: cursorMovementQueue, // Send all queued movements
+        name: settings.username,
+        id: 'cursor-' + UUID,
+        color: settings.color
+      })
+      cursorMovementQueue = [] // Clear the queue after sending
+    }
+  }
+
+  onMount(async () => {
+    settings = await window.BananasApi.getSettings()
+
+    makeVideoDraggable(remoteScreen)
+
+    remoteScreen.addEventListener('dblclick', () => {
+      webRTCComponent.PingRemoteCursor('cursor-' + UUID)
+    })
+
+    remoteScreen.addEventListener('mousemove', (e) => {
+      const { offsetX, offsetY } = e
+
+      // Normalize cursor position
+      const x = offsetX / remoteScreen.clientWidth
+      const y = offsetY / remoteScreen.clientHeight
+
+      cursorMovementQueue.push({ x, y })
+
+      if (!batchTimer) {
+        batchTimer = window.setInterval(() => {
+          sendBatchedCursorUpdates()
+        }, BATCH_SEND_INTERVAL)
+      }
+    })
+
+    remoteScreen.addEventListener('mouseout', () => {
+      if (batchTimer) {
+        clearInterval(batchTimer)
+        batchTimer = null
+        sendBatchedCursorUpdates() // Flush the queue immediately
+      }
+    })
+  })
+
+  const onFullscreenClick = (): void => {
+    remoteScreen.requestFullscreen()
+  }
+
+  const onZoomInClick = (): void => {
+    zoomFactor += 0.1
+    remoteScreen.style.scale = zoomFactor.toString()
+  }
+
+  const onZoomOutClick = (): void => {
+    if (zoomFactor <= 1) return
+    zoomFactor -= 0.1
+    remoteScreen.style.scale = zoomFactor.toString()
+  }
+
+  onDestroy(() => {
+    if (batchTimer) {
+      clearInterval(batchTimer)
+      batchTimer = null
+    }
+    sendBatchedCursorUpdates() // Send any remaining movements
+  })
+</script>
+
+<!--
+INFO:
+Show only when not streaming, because we only want one Desktop stream at a time
+and if you are the Host, you are already streaming your screen and thus should not
+be able to see the remote screen, which would be your own screen.
+-->
+<div class={isRemoteScreenVisible ? '' : 'is-hidden'}>
+  <div class="field">
+    <label class="label" for="remote_screen">Remote screen</label>
+    <div class="control">
+      <div class="video-overflow">
+        <video bind:this={remoteScreen} id="remote_screen" class="video" autoplay playsinline muted
+        ></video>
+      </div>
+    </div>
+  </div>
+  <div class="field">
+    <div class="control">
+      <button class="button is-info" on:click={onZoomInClick}>
+        <span class="icon">
+          <i class="fas fa-search-plus"></i>
+        </span>
+        <span>Zoom In</span>
+      </button>
+      <button class="button is-info" on:click={onZoomOutClick}>
+        <span class="icon">
+          <i class="fas fa-search-minus"></i>
+        </span>
+        <span>Zoom Out</span>
+      </button>
+      <button class="button is-info" on:click={onFullscreenClick}>
+        <span class="icon">
+          <i class="fas fa-expand"></i>
+        </span>
+        <span>Fullscreen</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .video {
+    width: 100%;
+    height: auto;
+    transition: transform 0.5s linear;
+  }
+  .video-overflow {
+    width: 100%;
+    height: auto;
+    overflow: hidden;
+  }
+</style>

--- a/src/renderer/src/StreamInterface.svelte
+++ b/src/renderer/src/StreamInterface.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { makeVideoDraggable, getUUIDv4 } from './Utils'
+  import WebRTC from './WebRTC.svelte'
+  import AudioVisualizer from './AudioVisualizer.svelte'
+
+  export let webRTCComponent: WebRTC
+
+  let remoteScreen: HTMLVideoElement
+  let UUID = getUUIDv4()
+  let zoomFactor = 1
+  let microphoneActive = false
+  let isStreaming = false
+  let visualizerIsActive: boolean = true
+
+  onMount(async () => {
+    const settings = await window.BananasApi.getSettings()
+    microphoneActive = settings.isMicrophoneEnabledOnConnect
+    makeVideoDraggable(remoteScreen)
+    remoteScreen.addEventListener('dblclick', () => {
+      webRTCComponent.PingRemoteCursor('cursor-' + UUID)
+    })
+    remoteScreen.addEventListener('mousemove', (e) => {
+      const { offsetX, offsetY } = e
+      // TODO: Batch cursor updates
+      webRTCComponent.UpdateRemoteCursor({
+        x: offsetX / remoteScreen.clientWidth,
+        y: offsetY / remoteScreen.clientHeight,
+        name: settings.username,
+        id: 'cursor-' + UUID,
+        color: settings.color
+      })
+    })
+    remoteScreen.addEventListener('play', () => {
+      if (!webRTCComponent.IsConnected()) return
+      isStreaming = true
+    })
+  })
+  const onDisconnectClick = async (): Promise<void> => {
+    await webRTCComponent.Disconnect()
+  }
+  const onFullscreenClick = (): void => {
+    remoteScreen.requestFullscreen()
+  }
+  const onZoomInClick = (): void => {
+    zoomFactor += 0.1
+    remoteScreen.style.scale = zoomFactor.toString()
+  }
+  const onZoomOutClick = (): void => {
+    if (zoomFactor <= 1) return
+    zoomFactor -= 0.1
+    remoteScreen.style.scale = zoomFactor.toString()
+  }
+  const onMicrophoneToggle = async (): Promise<void> => {
+    microphoneActive = !microphoneActive
+    webRTCComponent.ToggleMicrophone()
+  }
+</script>
+
+<div class="container p-5">
+  <h1 class="title">{!isStreaming ? 'Join' : 'Joined'} a session</h1>
+  <div class={!isStreaming ? 'is-hidden' : ''}>
+    <div class="fixed-grid">
+      <div class="grid">
+        <div class="cell">
+          <button
+            aria-label={microphoneActive ? 'Microphone active' : 'Microphone muted'}
+            title={microphoneActive ? 'Microphone active' : 'Microphone muted'}
+            class="button {microphoneActive ? 'is-success' : 'is-danger'}"
+            on:click={onMicrophoneToggle}
+          >
+            <span class="icon">
+              {#if microphoneActive}
+                <AudioVisualizer
+                  className="icon {!visualizerIsActive ? 'is-hidden' : ''}"
+                  bind:visualizerIsActive
+                  stream={webRTCComponent.GetAudioStream()}
+                />
+                <i class="fas fa-microphone {visualizerIsActive ? 'is-hidden' : ''}"></i>
+              {:else}
+                <i class="fas fa-microphone-slash"></i>
+              {/if}
+            </span>
+          </button>
+        </div>
+        <div class="cell has-text-right">
+          <button class="button is-danger" aria-label="Disconnect" on:click={onDisconnectClick}>
+            <span class="icon">
+              <i class="fas fa-unlink"></i>
+            </span>
+            <span>Disconnect</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class={!isStreaming ? 'is-hidden' : ''}>
+  <div class="field">
+    <label class="label" for="remote_screen">Remote screen</label>
+    <div class="control">
+      <div class="video-overflow">
+        <video bind:this={remoteScreen} id="remote_screen" class="video" autoplay playsinline muted
+        ></video>
+      </div>
+    </div>
+  </div>
+  <div class="field">
+    <div class="control">
+      <button class="button is-info" on:click={onZoomInClick}>
+        <span class="icon">
+          <i class="fas fa-search-plus"></i>
+        </span>
+        <span>Zoom In</span>
+      </button>
+      <button class="button is-info" on:click={onZoomOutClick}>
+        <span class="icon">
+          <i class="fas fa-search-minus"></i>
+        </span>
+        <span>Zoom Out</span>
+      </button>
+      <button class="button is-info" on:click={onFullscreenClick}>
+        <span class="icon">
+          <i class="fas fa-expand"></i>
+        </span>
+        <span>Fullscreen</span>
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .video {
+    width: 100%;
+    height: auto;
+    transition: transform 0.5s linear;
+  }
+  .video-overflow {
+    width: 100%;
+    height: auto;
+    overflow: hidden;
+  }
+</style>

--- a/src/renderer/src/StreamInterface.svelte
+++ b/src/renderer/src/StreamInterface.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onDestroy, onMount } from 'svelte'
   import { makeVideoDraggable, getUUIDv4 } from './Utils'
   import WebRTC from './WebRTC.svelte'
   import AudioVisualizer from './AudioVisualizer.svelte'
 
   export let webRTCComponent: WebRTC
+  export let connectionState: string = 'disconnected'
+
+  // Time interval for batching cursor updates (in ms)
+  const BATCH_SEND_INTERVAL = 100
+
+  let cursorMovementQueue: { x: number; y: number }[] = []
+  let batchTimer: number | null = null
 
   let remoteScreen: HTMLVideoElement
   let UUID = getUUIDv4()
@@ -12,91 +19,137 @@
   let microphoneActive = false
   let isStreaming = false
   let visualizerIsActive: boolean = true
+  let isConnected = connectionState === 'connected'
+  let settings = null
 
-  onMount(async () => {
-    const settings = await window.BananasApi.getSettings()
-    microphoneActive = settings.isMicrophoneEnabledOnConnect
-    makeVideoDraggable(remoteScreen)
-    remoteScreen.addEventListener('dblclick', () => {
-      webRTCComponent.PingRemoteCursor('cursor-' + UUID)
-    })
-    remoteScreen.addEventListener('mousemove', (e) => {
-      const { offsetX, offsetY } = e
-      // TODO: Batch cursor updates
+  function sendBatchedCursorUpdates(): void {
+    if (cursorMovementQueue.length > 0) {
       webRTCComponent.UpdateRemoteCursor({
-        x: offsetX / remoteScreen.clientWidth,
-        y: offsetY / remoteScreen.clientHeight,
+        movements: cursorMovementQueue, // Send all queued movements
         name: settings.username,
         id: 'cursor-' + UUID,
         color: settings.color
       })
+      cursorMovementQueue = [] // Clear the queue after sending
+    }
+  }
+
+  onMount(async () => {
+    settings = await window.BananasApi.getSettings()
+
+    microphoneActive = settings.isMicrophoneEnabledOnConnect
+    makeVideoDraggable(remoteScreen)
+
+    remoteScreen.addEventListener('dblclick', () => {
+      webRTCComponent.PingRemoteCursor('cursor-' + UUID)
     })
+
+    remoteScreen.addEventListener('mousemove', (e) => {
+      const { offsetX, offsetY } = e
+
+      // Normalize cursor position
+      const x = offsetX / remoteScreen.clientWidth
+      const y = offsetY / remoteScreen.clientHeight
+
+      cursorMovementQueue.push({ x, y })
+
+      if (!batchTimer) {
+        batchTimer = window.setInterval(() => {
+          sendBatchedCursorUpdates()
+        }, BATCH_SEND_INTERVAL)
+      }
+    })
+
+    remoteScreen.addEventListener('mouseout', () => {
+      if (batchTimer) {
+        clearInterval(batchTimer)
+        batchTimer = null
+        sendBatchedCursorUpdates() // Flush the queue immediately
+      }
+    })
+
     remoteScreen.addEventListener('play', () => {
       if (!webRTCComponent.IsConnected()) return
       isStreaming = true
     })
   })
+
   const onDisconnectClick = async (): Promise<void> => {
     await webRTCComponent.Disconnect()
   }
+
   const onFullscreenClick = (): void => {
     remoteScreen.requestFullscreen()
   }
+
   const onZoomInClick = (): void => {
     zoomFactor += 0.1
     remoteScreen.style.scale = zoomFactor.toString()
   }
+
   const onZoomOutClick = (): void => {
     if (zoomFactor <= 1) return
     zoomFactor -= 0.1
     remoteScreen.style.scale = zoomFactor.toString()
   }
+
   const onMicrophoneToggle = async (): Promise<void> => {
     microphoneActive = !microphoneActive
     webRTCComponent.ToggleMicrophone()
   }
+
+  onDestroy(() => {
+    if (batchTimer) {
+      clearInterval(batchTimer)
+      batchTimer = null
+    }
+    sendBatchedCursorUpdates() // Send any remaining movements
+  })
 </script>
 
-<div class="container p-5">
-  <h1 class="title">{!isStreaming ? 'Join' : 'Joined'} a session</h1>
-  <div class={!isStreaming ? 'is-hidden' : ''}>
-    <div class="fixed-grid">
-      <div class="grid">
-        <div class="cell">
-          <button
-            aria-label={microphoneActive ? 'Microphone active' : 'Microphone muted'}
-            title={microphoneActive ? 'Microphone active' : 'Microphone muted'}
-            class="button {microphoneActive ? 'is-success' : 'is-danger'}"
-            on:click={onMicrophoneToggle}
-          >
-            <span class="icon">
-              {#if microphoneActive}
-                <AudioVisualizer
-                  className="icon {!visualizerIsActive ? 'is-hidden' : ''}"
-                  bind:visualizerIsActive
-                  stream={webRTCComponent.GetAudioStream()}
-                />
-                <i class="fas fa-microphone {visualizerIsActive ? 'is-hidden' : ''}"></i>
-              {:else}
-                <i class="fas fa-microphone-slash"></i>
-              {/if}
-            </span>
-          </button>
-        </div>
-        <div class="cell has-text-right">
-          <button class="button is-danger" aria-label="Disconnect" on:click={onDisconnectClick}>
-            <span class="icon">
-              <i class="fas fa-unlink"></i>
-            </span>
-            <span>Disconnect</span>
-          </button>
-        </div>
+<div class="container p-5 {isConnected ? '' : 'is-hidden'}">
+  <div class="fixed-grid">
+    <div class="grid">
+      <div class="cell">
+        <button
+          aria-label={microphoneActive ? 'Microphone active' : 'Microphone muted'}
+          title={microphoneActive ? 'Microphone active' : 'Microphone muted'}
+          class="button {microphoneActive ? 'is-success' : 'is-danger'}"
+          on:click={onMicrophoneToggle}
+        >
+          <span class="icon">
+            {#if microphoneActive}
+              <AudioVisualizer
+                className="icon {!visualizerIsActive ? 'is-hidden' : ''}"
+                bind:visualizerIsActive
+                stream={webRTCComponent.GetAudioStream()}
+              />
+              <i class="fas fa-microphone {visualizerIsActive ? 'is-hidden' : ''}"></i>
+            {:else}
+              <i class="fas fa-microphone-slash"></i>
+            {/if}
+          </span>
+        </button>
+      </div>
+      <div class="cell has-text-right">
+        <button class="button is-danger" aria-label="Disconnect" on:click={onDisconnectClick}>
+          <span class="icon">
+            <i class="fas fa-unlink"></i>
+          </span>
+          <span>Disconnect</span>
+        </button>
       </div>
     </div>
   </div>
 </div>
 
-<div class={!isStreaming ? 'is-hidden' : ''}>
+<!--
+INFO:
+Show only when not streaming, because we only want one Desktop stream at a time
+and if you are the Host, you are already streaming your screen and thus should not
+be able to see the remote screen, which would be your own screen.
+-->
+<div class={isStreaming ? 'is-hidden' : ''}>
   <div class="field">
     <label class="label" for="remote_screen">Remote screen</label>
     <div class="control">

--- a/src/renderer/src/StreamInterface.svelte
+++ b/src/renderer/src/StreamInterface.svelte
@@ -1,96 +1,31 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte'
-  import { makeVideoDraggable, getUUIDv4 } from './Utils'
+  import { onMount } from 'svelte'
   import WebRTC from './WebRTC.svelte'
   import AudioVisualizer from './AudioVisualizer.svelte'
 
   export let webRTCComponent: WebRTC
-  export let connectionState: string = 'disconnected'
+  export let isReady: boolean = false
+  export let isStreaming = false
 
-  // Time interval for batching cursor updates (in ms)
-  const BATCH_SEND_INTERVAL = 100
+  let cursorsActive = false
 
-  let cursorMovementQueue: { x: number; y: number }[] = []
-  let batchTimer: number | null = null
-
-  let remoteScreen: HTMLVideoElement
-  let UUID = getUUIDv4()
-  let zoomFactor = 1
   let microphoneActive = false
-  let isStreaming = false
   let visualizerIsActive: boolean = true
-  let isConnected = connectionState === 'connected'
   let settings = null
 
-  function sendBatchedCursorUpdates(): void {
-    if (cursorMovementQueue.length > 0) {
-      webRTCComponent.UpdateRemoteCursor({
-        movements: cursorMovementQueue, // Send all queued movements
-        name: settings.username,
-        id: 'cursor-' + UUID,
-        color: settings.color
-      })
-      cursorMovementQueue = [] // Clear the queue after sending
-    }
+  const toggleRemoteCursors = (): void => {
+    cursorsActive = !cursorsActive
+    window.BananasApi.toggleRemoteCursors(cursorsActive)
+    webRTCComponent.ToggleRemoteCursors(cursorsActive)
   }
 
   onMount(async () => {
     settings = await window.BananasApi.getSettings()
-
     microphoneActive = settings.isMicrophoneEnabledOnConnect
-    makeVideoDraggable(remoteScreen)
-
-    remoteScreen.addEventListener('dblclick', () => {
-      webRTCComponent.PingRemoteCursor('cursor-' + UUID)
-    })
-
-    remoteScreen.addEventListener('mousemove', (e) => {
-      const { offsetX, offsetY } = e
-
-      // Normalize cursor position
-      const x = offsetX / remoteScreen.clientWidth
-      const y = offsetY / remoteScreen.clientHeight
-
-      cursorMovementQueue.push({ x, y })
-
-      if (!batchTimer) {
-        batchTimer = window.setInterval(() => {
-          sendBatchedCursorUpdates()
-        }, BATCH_SEND_INTERVAL)
-      }
-    })
-
-    remoteScreen.addEventListener('mouseout', () => {
-      if (batchTimer) {
-        clearInterval(batchTimer)
-        batchTimer = null
-        sendBatchedCursorUpdates() // Flush the queue immediately
-      }
-    })
-
-    remoteScreen.addEventListener('play', () => {
-      if (!webRTCComponent.IsConnected()) return
-      isStreaming = true
-    })
   })
 
   const onDisconnectClick = async (): Promise<void> => {
     await webRTCComponent.Disconnect()
-  }
-
-  const onFullscreenClick = (): void => {
-    remoteScreen.requestFullscreen()
-  }
-
-  const onZoomInClick = (): void => {
-    zoomFactor += 0.1
-    remoteScreen.style.scale = zoomFactor.toString()
-  }
-
-  const onZoomOutClick = (): void => {
-    if (zoomFactor <= 1) return
-    zoomFactor -= 0.1
-    remoteScreen.style.scale = zoomFactor.toString()
   }
 
   const onMicrophoneToggle = async (): Promise<void> => {
@@ -98,19 +33,24 @@
     webRTCComponent.ToggleMicrophone()
   }
 
-  onDestroy(() => {
-    if (batchTimer) {
-      clearInterval(batchTimer)
-      batchTimer = null
-    }
-    sendBatchedCursorUpdates() // Send any remaining movements
-  })
+  const requestStreamer = async (): Promise<void> => {
+    console.log('Requesting streamer')
+  }
 </script>
 
-<div class="container p-5 {isConnected ? '' : 'is-hidden'}">
+<div class="container p-5 {isReady ? '' : 'is-hidden'}">
   <div class="fixed-grid">
     <div class="grid">
       <div class="cell">
+        <button
+          title={isStreaming ? 'Stop streaming your screen' : 'Request to stream your screen'}
+          class="button {isStreaming ? 'is-success' : 'is-danger'}"
+          on:click={requestStreamer}
+        >
+          <span class="icon">
+            <i class="fa-solid fa-display"></i>
+          </span>
+        </button>
         <button
           aria-label={microphoneActive ? 'Microphone active' : 'Microphone muted'}
           title={microphoneActive ? 'Microphone active' : 'Microphone muted'}
@@ -130,6 +70,17 @@
             {/if}
           </span>
         </button>
+        <button
+          title={cursorsActive ? 'Remote cursors enabled' : 'Remote cursors disabled'}
+          class="button {cursorsActive ? 'is-success' : 'is-danger'} {isStreaming
+            ? ''
+            : 'is-hidden'}"
+          on:click={toggleRemoteCursors}
+        >
+          <span class="icon">
+            <i class="fas fa-mouse-pointer"></i>
+          </span>
+        </button>
       </div>
       <div class="cell has-text-right">
         <button class="button is-danger" aria-label="Disconnect" on:click={onDisconnectClick}>
@@ -142,56 +93,3 @@
     </div>
   </div>
 </div>
-
-<!--
-INFO:
-Show only when not streaming, because we only want one Desktop stream at a time
-and if you are the Host, you are already streaming your screen and thus should not
-be able to see the remote screen, which would be your own screen.
--->
-<div class={isStreaming ? 'is-hidden' : ''}>
-  <div class="field">
-    <label class="label" for="remote_screen">Remote screen</label>
-    <div class="control">
-      <div class="video-overflow">
-        <video bind:this={remoteScreen} id="remote_screen" class="video" autoplay playsinline muted
-        ></video>
-      </div>
-    </div>
-  </div>
-  <div class="field">
-    <div class="control">
-      <button class="button is-info" on:click={onZoomInClick}>
-        <span class="icon">
-          <i class="fas fa-search-plus"></i>
-        </span>
-        <span>Zoom In</span>
-      </button>
-      <button class="button is-info" on:click={onZoomOutClick}>
-        <span class="icon">
-          <i class="fas fa-search-minus"></i>
-        </span>
-        <span>Zoom Out</span>
-      </button>
-      <button class="button is-info" on:click={onFullscreenClick}>
-        <span class="icon">
-          <i class="fas fa-expand"></i>
-        </span>
-        <span>Fullscreen</span>
-      </button>
-    </div>
-  </div>
-</div>
-
-<style>
-  .video {
-    width: 100%;
-    height: auto;
-    transition: transform 0.5s linear;
-  }
-  .video-overflow {
-    width: 100%;
-    height: auto;
-    overflow: hidden;
-  }
-</style>

--- a/src/renderer/src/WebRTC.svelte
+++ b/src/renderer/src/WebRTC.svelte
@@ -63,7 +63,14 @@
       console.error('remoteMouseCursorPositionsChannel not ready')
       return
     }
-    remoteMouseCursorPositionsChannel.send(JSON.stringify(cursorData))
+    cursorData.movements.forEach((m) => {
+      const data = {
+        ...cursorData,
+        x: m.x,
+        y: m.y
+      }
+      remoteMouseCursorPositionsChannel.send(JSON.stringify(data))
+    })
   }
   export function HasAudioInput(): boolean {
     return audioStream !== null

--- a/src/renderer/src/WebRTC.svelte
+++ b/src/renderer/src/WebRTC.svelte
@@ -1,22 +1,30 @@
 <script lang="ts">
   import type { RTCSessionDescriptionOptions } from './Utils'
   import type { BananasRemoteCursorData, SettingsData } from './BananasTypes'
+  import { BananasConnectionState, BananasReadyState } from './BananasTypes'
   import { getConnectionString, ConnectionType } from './Utils'
   import { getRTCPeerConnectionConfig } from './Config'
+  import { onDestroy } from 'svelte'
 
-  export let connectionState: string = 'disconnected'
+  export let remoteScreen: HTMLVideoElement | null = null
+  export let connectionState: string = BananasConnectionState.DISCONNECTED
+  export let isStreaming = false
+  export let readyState: BananasReadyState = BananasReadyState.UNINITIALIZED
+  export let sessionStarted = false
+  export let isConnected = false
 
   const errorHander = (e: ErrorEvent): void => {
     console.error(e)
   }
 
-  let remoteVideo: HTMLVideoElement | null = null
   let pc: RTCPeerConnection | null = null
   let remoteCursorPositionsEnabled = false
   let remoteMouseCursorPositionsChannel: RTCDataChannel | null = null
   let remoteCursorPingChannel: RTCDataChannel | null = null
+  let signalingChannel: RTCDataChannel | null = null
   let audioStream: MediaStream | null = null
-  let stream: MediaStream | null = null
+  let videoStream: MediaStream | null = null
+  let videoSender: RTCRtpSender | null = null
   let audioElement: HTMLAudioElement | null = null
   let userSettings: SettingsData | null = null
 
@@ -37,7 +45,7 @@
       remoteMouseCursorPositionsChannel = dc
       dc.onmessage = function (e: MessageEvent): void {
         if (!remoteCursorPositionsEnabled) return
-        if (remoteVideo) return
+        if (isStreaming) return
         const data = JSON.parse(e.data)
         window.BananasApi.updateRemoteCursor(data)
       }
@@ -46,8 +54,14 @@
       remoteCursorPingChannel = dc
       dc.onmessage = function (e: MessageEvent): void {
         if (!remoteCursorPositionsEnabled) return
-        if (remoteVideo) return
+        if (isStreaming) return
         window.BananasApi.remoteCursorPing(e.data)
+      }
+    }
+    if (dc.label === 'signaling') {
+      signalingChannel = dc
+      dc.onopen = function (): void {
+        readyState = BananasReadyState.READY
       }
     }
   }
@@ -84,9 +98,40 @@
     remoteCursorPositionsEnabled = enabled
     return enabled
   }
-  export async function Setup(v: HTMLVideoElement = null): Promise<void> {
+  export async function RequestStartStreaming(): Promise<boolean> {
+    try {
+      videoStream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: false
+      })
+      videoSender = pc.addTrack(videoStream.getTracks()[0], videoStream)
+      isStreaming = true
+      return true
+    } catch (e) {
+      errorHander(e)
+      return false
+    }
+  }
+  export async function RequestStopStreaming(): Promise<boolean> {
+    try {
+      if (videoStream) {
+        pc.removeTrack(videoSender)
+        const track = videoSender.track
+        if (track) {
+          track.stop()
+        }
+        videoStream = null
+        videoSender = null
+      }
+      isStreaming = false
+      return true
+    } catch (e) {
+      errorHander(e)
+      return false
+    }
+  }
+  export async function Setup(): Promise<void> {
     userSettings = await window.BananasApi.getSettings()
-    remoteVideo = v
     audioElement = document.createElement('audio')
     audioElement.controls = true
     audioElement.autoplay = true
@@ -102,11 +147,12 @@
       if (e.channel.label === 'remoteCursorPing') {
         setupDataChannel(e.channel)
       }
+      if (e.channel.label === 'signaling') {
+        setupDataChannel(e.channel)
+      }
     }
     pc.ontrack = (evt): void => {
-      if (remoteVideo) {
-        remoteVideo.srcObject = evt.streams[0]
-      }
+      remoteScreen.srcObject = evt.streams[0]
       if (audioStream) {
         audioElement.srcObject = evt.streams[0]
       }
@@ -130,30 +176,10 @@
     } catch (e) {
       errorHander(e)
     }
-    if (!remoteVideo) {
-      try {
-        stream = await navigator.mediaDevices.getDisplayMedia({
-          video: true,
-          audio: false
-        })
-        for (const track of stream.getTracks()) {
-          pc.addTrack(track, stream)
-        }
-        if (audioStream) {
-          for (const track of audioStream.getTracks()) {
-            track.enabled = userSettings.isMicrophoneEnabledOnConnect
-            pc.addTrack(track, stream)
-          }
-        }
-      } catch (e) {
-        errorHander(e)
-      }
-    } else {
-      if (audioStream) {
-        for (const track of audioStream.getTracks()) {
-          track.enabled = userSettings.isMicrophoneEnabledOnConnect
-          pc.addTrack(track, audioStream)
-        }
+    if (audioStream) {
+      for (const track of audioStream.getTracks()) {
+        track.enabled = userSettings.isMicrophoneEnabledOnConnect
+        pc.addTrack(track, audioStream)
       }
     }
   }
@@ -176,15 +202,17 @@
   export async function CreateHostUrl(data: { username: string }): Promise<string> {
     remoteMouseCursorPositionsChannel = pc.createDataChannel('remoteMouseCursorPositions')
     remoteCursorPingChannel = pc.createDataChannel('remoteCursorPing')
+    signalingChannel = pc.createDataChannel('signaling')
     setupDataChannel(remoteMouseCursorPositionsChannel)
     setupDataChannel(remoteCursorPingChannel)
+    setupDataChannel(signalingChannel)
     const desc = await pc.createOffer()
     await pc.setLocalDescription(desc)
     return await getConnectionString(ConnectionType.HOST, pc.localDescription, data)
   }
   export function ToggleDisplayStream(): void {
-    if (stream) {
-      for (const track of stream.getVideoTracks()) {
+    if (videoStream) {
+      for (const track of videoStream.getVideoTracks()) {
         track.enabled = !track.enabled
       }
     }
@@ -223,11 +251,11 @@
     try {
       pc.close()
       pc = null
-      if (stream) {
-        for (const track of stream.getTracks()) {
+      if (videoStream) {
+        for (const track of videoStream.getTracks()) {
           track.stop()
         }
-        stream = null
+        videoStream = null
       }
       if (audioStream) {
         for (const track of audioStream.getTracks()) {
@@ -238,5 +266,61 @@
     } catch (e) {
       errorHander(e)
     }
+    readyState = BananasReadyState.UNINITIALIZED
+    sessionStarted = false
+    isConnected = false
   }
+
+  onDestroy(() => {
+    // Close the peer connection
+    if (pc) {
+      pc.close()
+      pc = null
+    }
+
+    // Stop and release all tracks in the audio stream
+    if (audioStream) {
+      for (const track of audioStream.getTracks()) {
+        track.stop()
+      }
+      audioStream = null
+    }
+
+    // Stop and release all tracks in the display/media stream
+    if (videoStream) {
+      for (const track of videoStream.getTracks()) {
+        track.stop()
+      }
+      videoStream = null
+    }
+
+    // Clean up data channels
+    if (signalingChannel) {
+      signalingChannel.close()
+      signalingChannel = null
+    }
+
+    if (remoteMouseCursorPositionsChannel) {
+      remoteMouseCursorPositionsChannel.close()
+      remoteMouseCursorPositionsChannel = null
+    }
+
+    if (remoteCursorPingChannel) {
+      remoteCursorPingChannel.close()
+      remoteCursorPingChannel = null
+    }
+
+    // Reset other references
+    if (audioElement) {
+      audioElement.srcObject = null
+      audioElement = null
+    }
+
+    if (remoteScreen) {
+      remoteScreen.srcObject = null
+    }
+
+    userSettings = null
+    remoteCursorPositionsEnabled = false
+  })
 </script>


### PR DESCRIPTION
It should be possible to hot swap seats.

This means, that not only the host should be able to share his screen, but also the participant should be able to request to take over screen sharing.

I think we should start simple and only allow one screen share at a time.

Also: the terms Host and Participant shouldn't change when you request to stream, because it's planned that the Host will be a relay to x-peers; see #48.

Which basically means whoever the Host is, needs a lot of ressources, because he will act as a proxy for all peers.

This closes #47 